### PR TITLE
Add propose_downstream for `/packit propose-update` comments

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -23,3 +23,13 @@ jobs:
     - fedora-29-x86_64
     - fedora-30-x86_64
     - fedora-rawhide-x86_64
+      
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist-git-branch: master
+
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist-git-branch: f30


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

Add propose-downstream jobs for testing packit-service `/packit propose-update`.

Does it make sense to you?