### PR TITLE
Basic test case: copr build only

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,8 +14,7 @@ jobs:
 - job: copr_build
   trigger: pull_request
   targets:
-  - fedora-stable-x86_64
-  - fedora-rawhide-x86_64
+  - fedora-all
 
 - job: copr_build
   trigger: release
@@ -27,12 +26,6 @@ jobs:
   branch: main
   targets:
     - fedora-stable
-
-- job: tests
-  trigger: pull_request
-  targets:
-  - fedora-stable-x86_64
-  - fedora-rawhide-x86_64
 
 - job: propose_downstream
   trigger: release


### PR DESCRIPTION
This test case is triggered automatically by our validation script.

```yaml
- job: copr_build
  trigger: pull_request
  targets:
  - fedora-all
```